### PR TITLE
Remove coding comment

### DIFF
--- a/snippets/python_snippets.json
+++ b/snippets/python_snippets.json
@@ -23,7 +23,6 @@
     "Import": {
         "prefix": "ooimport",
         "body": [
-            "# -*- coding: utf-8 -*-",
             "\nimport logging",
             "\nfrom odoo import _, api, fields, models",
             "\n_logger = logging.getLogger(__name__)",


### PR DESCRIPTION
This one is not really necessary anymore on Python 3, where all files are unicode always.

It's an OCA guideline to remove that when migrating modules to v11, which is already obsolete. All Odoo supported versions nowadays (12-14) use Python 3, so I think it's time to remove this.